### PR TITLE
Add Dependabot package upgrade weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This pull request introduces a configuration for Dependabot to automatically check for package upgrades on a weekly basis. The configuration will ensure that dependencies are regularly updated, improving security and keeping packages up-to-date with the latest patches.
