### PR TITLE
Configure Yarn to use 7-day minimal age gate for npm packages

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
 nodeLinker: node-modules
+npmMinimalAgeGate: "7d"


### PR DESCRIPTION
Add npmMinimalAgeGate security setting to prevent installing packages published within the last 7 days